### PR TITLE
Feature: Create json file line by line and filter using tags

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -19,6 +19,8 @@ type Config struct {
 	SourcePath       string
 	StoreToDir       string
 	SkipHTMLDecoding bool
+	FilterByTagId    string
+	JsonOneLine      bool
 }
 
 const (
@@ -101,7 +103,14 @@ func Convert(cfg Config) (err error) {
 	} else {
 		cfg.StoreToDir = sourcePathResolved
 	}
-
+	var tags []string
+	if cfg.FilterByTagId != "" {
+		tags = strings.Fields(cfg.FilterByTagId)
+		log.Printf("Filter tags containing: %s", tags)
+	}
+	if !(cfg.JsonOneLine) {
+		log.Printf("Write one json obj per line instead of array")
+	}
 	log.Printf("Total %d file(s) to convert", len(sourceFiles))
 
 	var wg sync.WaitGroup
@@ -112,7 +121,7 @@ func Convert(cfg Config) (err error) {
 			fmt.Sprintf("%s.%s", typeName, cfg.ResultFormat))
 		wg.Add(1)
 		log.Printf("[%s] Converting is started", typeName)
-		go convertXMLFile(&wg, typeName, sf, resultFile)
+		go convertXMLFile(&wg, typeName, sf, resultFile, tags, cfg.JsonOneLine)
 	}
 
 	wg.Wait()
@@ -120,7 +129,7 @@ func Convert(cfg Config) (err error) {
 	return
 }
 
-func convertXMLFile(wg *sync.WaitGroup, typeName string, xmlFilePath string, resultFilePath string) {
+func convertXMLFile(wg *sync.WaitGroup, typeName string, xmlFilePath string, resultFilePath string, tags []string, jsonOneline bool) {
 	xmlFile, err := os.Open(xmlFilePath)
 	if err != nil {
 		log.Printf("[%s] Error: %s", typeName, err)
@@ -138,9 +147,13 @@ func convertXMLFile(wg *sync.WaitGroup, typeName string, xmlFilePath string, res
 	var total, converted int64
 	switch converterConfig.ResultFormat {
 	case "csv":
+		if len(tags) != 0 {
+			log.Printf("Tag filter for csv not supported")
+			return
+		}
 		total, converted, err = convertToCSV(typeName, xmlFile, resultFile, converterConfig)
 	case "json":
-		total, converted, err = convertToJSON(typeName, xmlFile, resultFile, converterConfig)
+		total, converted, err = convertToJSON(typeName, xmlFile, resultFile, converterConfig, tags, jsonOneline)
 	}
 
 	if err != nil {

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -20,6 +20,7 @@ type Config struct {
 	StoreToDir       string
 	SkipHTMLDecoding bool
 	FilterByTagId    string
+	FilterExactMatch bool
 	JsonOneLine      bool
 }
 
@@ -108,6 +109,9 @@ func Convert(cfg Config) (err error) {
 		tags = strings.Fields(cfg.FilterByTagId)
 		log.Printf("Filter tags containing: %s", tags)
 	}
+	if !(cfg.FilterExactMatch) {
+		log.Printf("Filter tags have to match exactly")
+	}
 	if !(cfg.JsonOneLine) {
 		log.Printf("Write one json obj per line instead of array")
 	}
@@ -121,7 +125,7 @@ func Convert(cfg Config) (err error) {
 			fmt.Sprintf("%s.%s", typeName, cfg.ResultFormat))
 		wg.Add(1)
 		log.Printf("[%s] Converting is started", typeName)
-		go convertXMLFile(&wg, typeName, sf, resultFile, tags, cfg.JsonOneLine)
+		go convertXMLFile(&wg, typeName, sf, resultFile, tags, cfg.JsonOneLine, !(cfg.FilterExactMatch))
 	}
 
 	wg.Wait()
@@ -129,7 +133,7 @@ func Convert(cfg Config) (err error) {
 	return
 }
 
-func convertXMLFile(wg *sync.WaitGroup, typeName string, xmlFilePath string, resultFilePath string, tags []string, jsonOneline bool) {
+func convertXMLFile(wg *sync.WaitGroup, typeName string, xmlFilePath string, resultFilePath string, tags []string, jsonOneline bool, filterExactMatch bool) {
 	xmlFile, err := os.Open(xmlFilePath)
 	if err != nil {
 		log.Printf("[%s] Error: %s", typeName, err)
@@ -153,7 +157,7 @@ func convertXMLFile(wg *sync.WaitGroup, typeName string, xmlFilePath string, res
 		}
 		total, converted, err = convertToCSV(typeName, xmlFile, resultFile, converterConfig)
 	case "json":
-		total, converted, err = convertToJSON(typeName, xmlFile, resultFile, converterConfig, tags, jsonOneline)
+		total, converted, err = convertToJSON(typeName, xmlFile, resultFile, converterConfig, tags, jsonOneline, filterExactMatch)
 	}
 
 	if err != nil {

--- a/converter/json.go
+++ b/converter/json.go
@@ -14,15 +14,10 @@ import (
 // WriteBufferSize bytes (8MB)
 const WriteBufferSize = 8388608
 
-func convertToJSON(typeName string, xmlFile *os.File, jsonFile *os.File, cfg Config, tags []string, oneLine bool) (total int64, converted int64, err error) {
+func convertToJSON(typeName string, xmlFile *os.File, jsonFile *os.File, cfg Config, tags []string, oneLine bool, filterExactMatch bool) (total int64, converted int64, err error) {
 	iterator := NewIterator(xmlFile)
-	log.Printf(jsonFile.Name())
 	w := bufio.NewWriterSize(jsonFile, WriteBufferSize)
 	defer w.Flush()
-	if oneLine == false {
-		log.Printf("oneline not set")
-		w.WriteByte('[')
-	}
 	var iErr error
 	for iterator.Next() {
 		if total > 0 && iErr == nil {
@@ -56,7 +51,11 @@ func convertToJSON(typeName string, xmlFile *os.File, jsonFile *os.File, cfg Con
 			tagsVar := re.FindString(string(ji))
 			// check if we the post is tagged with a label we are intested in
 			for i := 0; i < len(tags) && ignorePost; i++ {
-				ignorePost = !(strings.Contains(tagsVar, "<" + tags[i] + ">"))
+				if filterExactMatch {
+					ignorePost = !(strings.Contains(tagsVar, "<" + tags[i] + ">"))
+				} else {
+					ignorePost = !(strings.Contains(tagsVar, tags[i]))
+				}
 			}
 		}
 		if !(ignorePost) {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ func main() {
 	flag.StringVar(&cfg.SourcePath, "source-path", "", "Path to XML file(s)")
 	flag.StringVar(&cfg.StoreToDir, "store-to-dir", "", "Path where to store CSV file(s)")
 	flag.BoolVar(&cfg.SkipHTMLDecoding, "skip-html-decoding", false, "Path where to store CSV file(s)")
+	flag.StringVar(&cfg.FilterByTagId, "filter-by-tag-id", "", "Filter for tags, space sperated list")
+	flag.BoolVar(&cfg.JsonOneLine, "json-one-line", false, "Save json file as one object per line")
 	flag.Parse()
 
 	var err error

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 	flag.StringVar(&cfg.StoreToDir, "store-to-dir", "", "Path where to store CSV file(s)")
 	flag.BoolVar(&cfg.SkipHTMLDecoding, "skip-html-decoding", false, "Path where to store CSV file(s)")
 	flag.StringVar(&cfg.FilterByTagId, "filter-by-tag-id", "", "Filter for tags, space sperated list")
+	flag.BoolVar(&cfg.FilterExactMatch, "filter-no-exact-match", false, "Match tags that contain the keywords specified by filter-by-tag-id instead of matching by exact matches only")
 	flag.BoolVar(&cfg.JsonOneLine, "json-one-line", false, "Save json file as one object per line")
 	flag.Parse()
 


### PR DESCRIPTION
I propose two features with this MR:
The first change enables changing the json output to write one json-object per line per post.
The second change introduces a filter mechanism that can be used to filter the dataset while converting it.
Imagine you only care about some tags related to testing. With the new features you can do something like:

```
./stackexchange-xml-converter \
    -result-format=json \
    -source-path=../data/Posts.xml\
    -store-to-dir "../data" \
    -filter-by-tag-id "\
        tdd\
        testing\
        testcase testing-library\
        unit-testing"\
    -json-one-line
```
You will get a filtered dataset of posts that have one of those tags assigned. For each there is one json object per line in the resulting `Posts.json` file.
Then I also added another flag that allows you to include tags where the word is contained in one of the tags.
The following would give you all posts with tags that contain the word 'testing' (e.g. unit-testing, testing-library).

```
./stackexchange-xml-converter \
    -result-format=json \
    -source-path=../data/Posts.xml
    -store-to-dir "../data" \
    -filter-by-tag-id "\
        testing\
    -json-one-line\
    -filter-no-exact-match
```

If you approve to the changes I'd be happy to rebase and refactor.